### PR TITLE
fix: create different subjects when `destroyMethodName` is provided

### DIFF
--- a/integration/app/issue-sixty-six/issue-sixty-six.component.html
+++ b/integration/app/issue-sixty-six/issue-sixty-six.component.html
@@ -1,4 +1,5 @@
-<br />
-<a href="https://github.com/ngneat/until-destroy/issues/66">Issue 66</a>
-<button (click)="start()">start</button>
-<button (click)="stop()">stop</button>
+<button (click)="startFirst()">IssueSixtySixComponent.startFirst()</button>
+<button (click)="stopFirst()">IssueSixtySixComponent.stopFirst()</button>
+<button (click)="startSecond()">IssueSixtySixComponent.startSecond()</button>
+<button (click)="stopSecond()">IssueSixtySixComponent.stopSecond()</button>
+<hr />

--- a/integration/app/issue-sixty-six/issue-sixty-six.component.ts
+++ b/integration/app/issue-sixty-six/issue-sixty-six.component.ts
@@ -5,16 +5,39 @@ import { finalize } from 'rxjs/operators';
 
 @Injectable({ providedIn: 'root' })
 export class IssueSixtySixService {
-  start(): void {
+  startFirst(): void {
     interval(1000)
       .pipe(
-        untilDestroyed(this, 'stop'),
-        finalize(() => console.log('IssueSixtySixService interval stream has completed'))
+        untilDestroyed(this, 'stopFirst'),
+        finalize(() =>
+          console.log(
+            'IssueSixtySixService.startFirst() interval stream has been unsubscribed'
+          )
+        )
       )
-      .subscribe(value => console.log(`IssueSixtySixService has emitted value ${value}`));
+      .subscribe(value =>
+        console.log(`IssueSixtySixService.startFirst() has emitted value ${value}`)
+      );
   }
 
-  stop(): void {}
+  stopFirst(): void {}
+
+  startSecond(): void {
+    interval(1000)
+      .pipe(
+        untilDestroyed(this, 'stopSecond'),
+        finalize(() =>
+          console.log(
+            'IssueSixtySixService.startSecond() interval stream has been unsubscribed'
+          )
+        )
+      )
+      .subscribe(value =>
+        console.log(`IssueSixtySixService.startSecond() has emitted value ${value}`)
+      );
+  }
+
+  stopSecond(): void {}
 }
 
 @Component({
@@ -24,11 +47,19 @@ export class IssueSixtySixService {
 export class IssueSixtySixComponent {
   constructor(private issueSixtySixService: IssueSixtySixService) {}
 
-  start(): void {
-    this.issueSixtySixService.start();
+  startFirst(): void {
+    this.issueSixtySixService.startFirst();
   }
 
-  stop(): void {
-    this.issueSixtySixService.stop();
+  stopFirst(): void {
+    this.issueSixtySixService.stopFirst();
+  }
+
+  startSecond(): void {
+    this.issueSixtySixService.startSecond();
+  }
+
+  stopSecond(): void {
+    this.issueSixtySixService.stopSecond();
   }
 }

--- a/src/lib/until-destroy.ts
+++ b/src/lib/until-destroy.ts
@@ -6,6 +6,7 @@ import {
 
 import {
   getDef,
+  getSymbol,
   isFunction,
   UntilDestroyOptions,
   completeSubjectOnTheInstance,
@@ -31,7 +32,7 @@ function decorateNgOnDestroy(
 
     // It's important to use `this` instead of caching instance
     // that may lead to memory leaks
-    completeSubjectOnTheInstance(this);
+    completeSubjectOnTheInstance(this, getSymbol());
 
     // Check if subscriptions are pushed to some array
     if (arrayName) {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/until-destroy/blob/master/CONTRIBUTING.md#commit
- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #66

## What is the new behavior?

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
