### PR TITLE
fix(lib): detect decorator in abstract component (ngneat#97)

### DIFF
--- a/src/lib/internals.ts
+++ b/src/lib/internals.ts
@@ -41,7 +41,14 @@ export function getSymbol<T>(destroyMethodName?: keyof T): symbol {
 export function missingDecorator<T>(
   providerOrDef: InjectableType<T> | PipeDef<T> | ComponentDef<T> | DirectiveDef<T>
 ): boolean {
-  return !(providerOrDef as any)[DECORATOR_APPLIED];
+  // If doesn't have proto the function will be called with null
+  if (!providerOrDef) {
+    return true;
+  }
+  // Before assume that the component is not decorated, check the proto to look for abstract component decorated
+  return (providerOrDef as any)[DECORATOR_APPLIED]
+    ? false
+    : missingDecorator((providerOrDef as any)?.type?.prototype?.__proto__);
 }
 
 export function markAsDecorated<T>(

--- a/src/lib/ivy.ts
+++ b/src/lib/ivy.ts
@@ -26,13 +26,15 @@ export interface PipeType<T> extends Type<T> {
 
 // As directive and component definitions are considered private API,
 // so those properties are prefixed with Angular's marker for "private".
+// An abstract component is not decorated by angular, so we should return the prototype.
 export function getDef<T>(
   type: PipeType<T> | ComponentType<T> | DirectiveType<T>
 ): PipeDef<T> | DirectiveDef<T> | ComponentDef<T> {
   return (
     (type as PipeType<T>)[NG_PIPE_DEF] ||
     (type as ComponentType<T>)[NG_COMP_DEF] ||
-    (type as DirectiveType<T>)[NG_DIR_DEF]
+    (type as DirectiveType<T>)[NG_DIR_DEF] ||
+    type.prototype
   );
 }
 

--- a/src/lib/ivy.ts
+++ b/src/lib/ivy.ts
@@ -26,7 +26,7 @@ export interface PipeType<T> extends Type<T> {
 
 // As directive and component definitions are considered private API,
 // so those properties are prefixed with Angular's marker for "private".
-// An abstract component is not decorated by angular, so we should return the prototype.
+// An abstract component without @Directive() is not decorated by angular, so we should return the prototype.
 export function getDef<T>(
   type: PipeType<T> | ComponentType<T> | DirectiveType<T>
 ): PipeDef<T> | DirectiveDef<T> | ComponentDef<T> {
@@ -38,6 +38,10 @@ export function getDef<T>(
   );
 }
 
+export function getDirectiveDef(type: any) {
+  return type[NG_DIR_DEF];
+}
+
 export function getDefName<T>(type: PipeType<T> | ComponentType<T> | DirectiveType<T>) {
   if (type.hasOwnProperty(NG_PIPE_DEF)) {
     return NG_PIPE_DEF;
@@ -46,6 +50,14 @@ export function getDefName<T>(type: PipeType<T> | ComponentType<T> | DirectiveTy
   } else {
     return NG_DIR_DEF;
   }
+}
+
+export function getParentAbstractComponentDirective<T>(def: any): DirectiveDef<T> {
+  return (
+    (def.type as PipeType<T>)[NG_PIPE_DEF] ||
+    (def.type as ComponentType<T>)[NG_COMP_DEF] ||
+    (def.type as DirectiveType<T>)[NG_DIR_DEF]
+  );
 }
 
 // Determines whether the provided `target` is some function


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/until-destroy/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Inherit from abstract component throws an error

Issue Number: #97 

## What is the new behavior?
You should be able to inherit from an abstract component and everything should work

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

I'm Working on the tests. I submit the PR to show the approach on this issue, I've tested with the Reproducible example on the issue and it seems to work. I had some troubles trying to run the integration test (Them didn't work in my environment wirh no changes in the repo). But as I said before the idea is to check the approach I take and get your feedback.

Thanks.