### PR TITLE
fix(migration): add line break before UntilDestroy decorator

### DIFF
--- a/migration/fixtures/single-import.component.ts
+++ b/migration/fixtures/single-import.component.ts
@@ -2,6 +2,7 @@ import { of } from 'rxjs';
 import { untilDestroyed } from 'ngx-take-until-destroy';
 import { OnDestroy } from '@angular/core';
 
+// test comment
 @Component({ template: '' })
 export class SingleImportComponent extends BaseComponent implements OnDestroy {
   create() {

--- a/migration/run.spec.ts
+++ b/migration/run.spec.ts
@@ -65,6 +65,11 @@ describe('Migration script', () => {
       expect(result).not.toContain('ngOnDestroy()');
     });
 
+    it('should place @UntilDestroy decorator to a new line after the comment', () => {
+      const result = transformCode(code, 'single-import.component.ts', true);
+      expect(result).toContain(`// test comment\n@UntilDestroy()`);
+    });
+
     it('should remove class implements', () => {
       const result = transformCode(code, 'single-import.component.ts', true);
       expect(result).toContain(`export class SingleImportComponent extends BaseComponent {`);

--- a/migration/run.ts
+++ b/migration/run.ts
@@ -64,12 +64,7 @@ function replaceOldImport(sourceFile: SourceFile) {
 }
 
 function addUntilDestroyDecorator(classDeclaration: ClassDeclaration) {
-  const decorators = [
-    { name: 'UntilDestroy', arguments: [] },
-    ...(classDeclaration.getStructure().decorators || [])
-  ];
-  classDeclaration.getDecorators().forEach(d => d.remove());
-  classDeclaration.addDecorators(decorators);
+  classDeclaration.insertDecorator(0, { name: 'UntilDestroy', arguments: [] });
 }
 
 function removeOnDestroyImplements(classDeclaration: ClassDeclaration) {


### PR DESCRIPTION
## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[x] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[ ] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

Issue Number: [113](https://github.com/ngneat/until-destroy/issues/113)

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```
