### PR TITLE
fix: support non experimental decorators

### DIFF
--- a/libs/until-destroy/src/lib/until-destroy.ts
+++ b/libs/until-destroy/src/lib/until-destroy.ts
@@ -1,5 +1,6 @@
 import {
   InjectableType,
+  TypeDecorator,
   ɵComponentType as ComponentType,
   ɵDirectiveType as DirectiveType,
 } from '@angular/core';
@@ -65,7 +66,7 @@ function decoratePipe<T>(type: PipeType<T>, options: UntilDestroyOptions): void 
   def.onDestroy = decorateNgOnDestroy(def.onDestroy, options);
 }
 
-export function UntilDestroy(options: UntilDestroyOptions = {}): ClassDecorator {
+export function UntilDestroy(options: UntilDestroyOptions = {}): TypeDecorator {
   return (type: any) => {
     if (isPipe(type)) {
       decoratePipe(type, options);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://github.com/ngneat/until-destroy/blob/master/CONTRIBUTING.md#commit
- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

```
[ ] Bugfix
[ ] Feature
[ ] Code style update (formatting, local variables)
[ ] Refactoring (no functional changes, no api changes)
[x] Build related changes
[ ] CI related changes
[ ] Documentation content changes
[ ] Other... Please describe:
```

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

With TS 5.0 and Angular 16 the `@UntilDestroy` decorator is not compatible with disabling `experimentalDecorators`

Issue Number: #229

## What is the new behavior?

Will not work when experimental flag is disabled.

## Does this PR introduce a breaking change?

```
[ ] Yes
[x] No
```

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
